### PR TITLE
移除了抽象类方法里面的public修饰词

### DIFF
--- a/core/src/main/java/com/qq/tars/common/Filter.java
+++ b/core/src/main/java/com/qq/tars/common/Filter.java
@@ -5,10 +5,10 @@ import com.qq.tars.net.core.Response;
 
 public interface Filter {
 	
-	public void init();
+	void init();
 	
-	public void doFilter(Request request, Response response, FilterChain chain) throws Throwable;
+	void doFilter(Request request, Response response, FilterChain chain) throws Throwable;
 	
-	public void destroy();
+	void destroy();
 
 }

--- a/core/src/main/java/com/qq/tars/common/FilterChain.java
+++ b/core/src/main/java/com/qq/tars/common/FilterChain.java
@@ -4,6 +4,5 @@ import com.qq.tars.net.core.Request;
 import com.qq.tars.net.core.Response;
 
 public interface FilterChain {
-	
-	public void doFilter(Request request, Response response) throws Throwable;
+	void doFilter(Request request, Response response) throws Throwable;
 }


### PR DESCRIPTION
在section 9.4 of the Java Language Specification中提及java抽象类方法的修饰词默认是public，实际上使用protected、private也会引发错误，源码中有两个文件使用了public修饰符，显得多余，而且在idea、eclipse中也会提醒删除public，删掉他吧，使得代码更加简洁。