### PR TITLE
fix issue 19--异步超时的生效问题

### DIFF
--- a/core/src/main/java/com/qq/tars/client/Communicator.java
+++ b/core/src/main/java/com/qq/tars/client/Communicator.java
@@ -21,6 +21,7 @@ import com.qq.tars.client.util.ClientLogger;
 import com.qq.tars.common.support.ScheduledExecutorManager;
 import com.qq.tars.common.util.StringUtils;
 import com.qq.tars.net.client.ticket.TicketManager;
+import com.qq.tars.net.client.ticket.TimeoutManager;
 import com.qq.tars.rpc.common.LoadBalance;
 import com.qq.tars.rpc.common.ProtocolInvoker;
 import com.qq.tars.rpc.exc.CommunicatorConfigException;
@@ -91,6 +92,7 @@ public final class Communicator {
         this.threadPoolExecutor.shutdownNow();
         ScheduledExecutorManager.getInstance().shutdownNow();
         TicketManager.shutdown();
+        TimeoutManager.shutdown();
         for (Iterator<Object> it = servantProxyFactory.getProxyIterator(); it.hasNext(); ) {
             Object proxy = it.next();
             ((ObjectProxy) Proxy.getInvocationHandler(proxy)).destroy();

--- a/core/src/main/java/com/qq/tars/client/rpc/ServantClient.java
+++ b/core/src/main/java/com/qq/tars/client/rpc/ServantClient.java
@@ -163,7 +163,7 @@ public class ServantClient {
         try {
             ensureConnected();
             request.setInvokeStatus(InvokeStatus.ASYNC_CALL);
-            ticket = TicketManager.createTicket(request, session, this.asyncTimeout, callback);
+            ticket = TicketManager.createTicket(request, session, this.asyncTimeout, callback, selectorManager);
 
             Session current = session;
             current.write(request);

--- a/net/src/main/java/com/qq/tars/net/client/ticket/TimeoutManager.java
+++ b/net/src/main/java/com/qq/tars/net/client/ticket/TimeoutManager.java
@@ -1,0 +1,70 @@
+/**
+ * Tencent is pleased to support the open source community by making Tars available.
+ *
+ * Copyright (C) 2016 THL A29 Limited, a Tencent company. All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.qq.tars.net.client.ticket;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class TimeoutManager {
+
+	protected static ScheduledExecutorService scheduled = Executors.newScheduledThreadPool(2);
+
+	public static class TimeoutTask implements  Runnable{
+
+		Ticket<?> ticket;
+
+		public TimeoutTask(Ticket<?> ticket) {
+			this.ticket = ticket;
+		}
+
+		@Override
+		public void run() {
+			try {
+				TicketManager.removeTicket(this.ticket.getTicketNumber());   //从ticketmanager中移除掉ticket
+				this.ticket.expired();   //触发超时回调，通知业务方
+			} catch(Exception e) {
+				System.out.println("timeout exception:" + e);
+			}
+		}
+	}
+	/**
+	 * 	添加定时任务到线程池执行
+	 * @param task
+	 * @param timeout ms
+	 * @return
+	 */
+	public static Future<?> watch(Runnable task, long timeout) {
+		return scheduled.schedule(task, timeout, TimeUnit.MILLISECONDS);
+	}
+
+	/**
+	 * cancel超时的定时任务
+	 * @param ticket
+	 * @return
+	 */
+	public static boolean cancelTimeoutTask(Ticket<?> ticket) {
+		return ticket.getTimeoutFuture().cancel(false);
+	}
+
+	public static void shutdown() {
+		scheduled.shutdownNow();
+	}
+
+
+}

--- a/net/src/main/java/com/qq/tars/net/core/nio/WorkThread.java
+++ b/net/src/main/java/com/qq/tars/net/core/nio/WorkThread.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import com.qq.tars.net.client.ticket.Ticket;
 import com.qq.tars.net.client.ticket.TicketManager;
+import com.qq.tars.net.client.ticket.TimeoutManager;
 import com.qq.tars.net.core.Request;
 import com.qq.tars.net.core.Response;
 
@@ -91,6 +92,9 @@ public final class WorkThread implements Runnable {
                 ticket.notifyResponse(resp);
                 ticket.countDown();
                 TicketManager.removeTicket(ticket.getTicketNumber());
+                if(ticket.getTimeoutFuture() != null) {   //成功收到包,取消超时任务
+                    TimeoutManager.cancelTimeoutTask(ticket);
+                }
             }
         } catch (Exception ex) {
             ex.printStackTrace();


### PR DESCRIPTION
fix issue 19：https://github.com/TarsCloud/TarsJava/issues/19

* 原因：之前版本检测异步是否超时是通过轮询遍历请求（500ms）来实现，如果超时时间小于500ms，这种方式是检测不出来的;

* 修复：每个请求添加一个定时器，定时触发超时逻辑，如果正常收包，那么cancel掉超时任务.