### PR TITLE
修复split正则表达式错误

### DIFF
--- a/core/src/main/java/com/qq/tars/client/CommunicatorConfig.java
+++ b/core/src/main/java/com/qq/tars/client/CommunicatorConfig.java
@@ -253,7 +253,7 @@ public class CommunicatorConfig {
     public CommunicatorConfig setSetDivision(String setDivision) {
         this.setDivision = setDivision;
         if (setDivision != null) {
-            String[] tmp = StringUtils.split(setDivision, ".");
+            String[] tmp = StringUtils.split(setDivision, "\\.");
             if (tmp != null && tmp.length == 3) {
                 setName = tmp[0];
                 setArea = tmp[1];


### PR DESCRIPTION
java中split使用的是正则表达式，使用"."无法达成预期效果。