### PR TITLE
fix NPE bug in AbstractFilterChain

### DIFF
--- a/core/src/main/java/com/qq/tars/common/AbstractFilterChain.java
+++ b/core/src/main/java/com/qq/tars/common/AbstractFilterChain.java
@@ -1,6 +1,5 @@
 package com.qq.tars.common;
 
-import com.qq.tars.common.util.CollectionUtils;
 import com.qq.tars.net.core.Request;
 import com.qq.tars.net.core.Response;
 
@@ -9,27 +8,24 @@ import java.util.List;
 
 public abstract class AbstractFilterChain<T> implements FilterChain {
 
-    private List<Filter> filters;
-
     protected String servant;
-
     protected FilterKind kind;
-
     protected T target;
-
-    private Iterator<Filter> iteator;
+    private Iterator<Filter> iterator;
 
     public AbstractFilterChain(List<Filter> filters, String servant, FilterKind kind, T target) {
-        this.filters = filters;
         this.servant = servant;
         this.kind = kind;
         this.target = target;
+        if (filters != null) {
+            this.iterator = filters.iterator();
+        }
     }
 
     @Override
     public void doFilter(Request request, Response response) throws Throwable {
         Filter filter = getFilter();
-        if (CollectionUtils.isNotEmpty(filters)) {
+        if (filter != null) {
             filter.doFilter(request, response, this);
         } else {
             doRealInvoke(request, response);
@@ -38,17 +34,7 @@ public abstract class AbstractFilterChain<T> implements FilterChain {
     }
 
     private Filter getFilter() {
-
-        if (CollectionUtils.isEmpty(filters)) {
-            return null;
-        }
-        if (iteator == null) {
-            iteator = filters.iterator();
-        }
-        if (iteator.hasNext()) {
-            return iteator.next();
-        }
-        return null;
+        return iterator != null && iterator.hasNext() ? iterator.next() : null;
     }
 
     protected abstract void doRealInvoke(Request request, Response response) throws Throwable;

--- a/core/src/main/java/com/qq/tars/server/apps/BaseAppContext.java
+++ b/core/src/main/java/com/qq/tars/server/apps/BaseAppContext.java
@@ -59,6 +59,9 @@ public abstract class BaseAppContext implements AppContext {
 
 
     BaseAppContext() {
+        this.filters.put(FilterKind.SERVER, new LinkedList<>());
+        this.filters.put(FilterKind.CLIENT, new LinkedList<>());
+        this.filters.put(FilterKind.CALLBACK, new LinkedList<>());
     }
 
     @Override
@@ -128,10 +131,6 @@ public abstract class BaseAppContext implements AppContext {
     }
 
     void loadDefaultFilter() {
-        filters.put(FilterKind.SERVER, new LinkedList<Filter>());
-        filters.put(FilterKind.CLIENT, new LinkedList<Filter>());
-        filters.put(FilterKind.CALLBACK, new LinkedList<Filter>());
-
         List<Filter> serverFilters = filters.get(FilterKind.SERVER);
         Filter traceServerFilter = new TraceServerFilter();
         traceServerFilter.init();
@@ -159,11 +158,6 @@ public abstract class BaseAppContext implements AppContext {
     }
 
     @Override
-    public String getInitParameter(String name) {
-        return contextParams.get(name);
-    }
-
-    @Override
     public String name() {
         return "";
     }
@@ -182,5 +176,11 @@ public abstract class BaseAppContext implements AppContext {
             throw new RuntimeException("The application isn't started.");
         }
         return filters.get(kind);
+    }
+
+    @Override
+    public void addFilter(FilterKind kind, Filter filter) {
+        List<Filter> filters = this.filters.get(kind);
+        filters.add(filter);
     }
 }

--- a/core/src/main/java/com/qq/tars/server/core/AppContext.java
+++ b/core/src/main/java/com/qq/tars/server/core/AppContext.java
@@ -23,8 +23,6 @@ import java.util.List;
 
 public interface AppContext {
 
-    String getInitParameter(String name);
-
     String name();
 
     void stop();
@@ -32,6 +30,8 @@ public interface AppContext {
     ServantHomeSkeleton getCapHomeSkeleton(String homeName);
 
     List<Filter> getFilters(FilterKind kind);
+
+    void addFilter(FilterKind kind, Filter filter);
 
     void init();
 }


### PR DESCRIPTION
```
    @Override
    public void doFilter(Request request, Response response) throws Throwable {
        Filter filter = getFilter();
        if (CollectionUtils.isNotEmpty(filters)) {
            filter.doFilter(request, response, this);
        } else {
            doRealInvoke(request, response);
        }
    }
```

In previous code, if filters is not empty (using XmlAppContext to load default filters), doRealInvoke will never be called and filter will be null which causes NPE issue