### PR TITLE
[BUGFIX]fix:callback onException在异常时会被调用两次&&1.7.0-SNAPSHOT版本中初始化ObjectProxy时Invoker列表empty

### DIFF
--- a/core/src/main/java/com/qq/tars/client/rpc/ServantProtocolInvoker.java
+++ b/core/src/main/java/com/qq/tars/client/rpc/ServantProtocolInvoker.java
@@ -52,7 +52,7 @@ public abstract class ServantProtocolInvoker<T> implements ProtocolInvoker<T> {
         this.servantProxyConfig = config;
         this.threadPoolExecutor = threadPoolExecutor;
         this.protocolFactory = protocolFactory;
-        this.initInvoker();
+        this.allInvoker = this.initInvoker();
     }
 
     public abstract Invoker<T> create(Class<T> api, Url url) throws Exception;
@@ -70,7 +70,6 @@ public abstract class ServantProtocolInvoker<T> implements ProtocolInvoker<T> {
         logger.info("try to refresh " + servantProxyConfig.getSimpleObjectName());
         final List<Invoker<T>> invokers = new ArrayList<>(allInvoker);//copy invoker for destroy
         this.allInvoker = this.initInvoker();
-        this.initInvoker();
         destroy(invokers);
     }
 

--- a/core/src/main/java/com/qq/tars/client/rpc/tars/TarsCallbackWrapper.java
+++ b/core/src/main/java/com/qq/tars/client/rpc/tars/TarsCallbackWrapper.java
@@ -76,7 +76,9 @@ public class TarsCallbackWrapper implements Callback<TarsServantResponse> {
         } catch (Throwable ex) {
             ret = Constants.INVOKE_STATUS_EXEC;
             logger.error("error occurred on callback completed", ex);
-            onException(ex);
+            // fix: callback.onException() invoked in TarsAbstractCallback#doRealInvoke when execute exception, then throw ex
+            // so callback.onException() will be called twice!
+            // onException(ex);
         } finally {
             afterCallback();
             InvokeStatHelper.getInstance().addProxyStat(objName).addInvokeTimeByClient(config.getModuleName(), config.getSlaveName(), config.getSlaveSetName(), config.getSlaveSetArea(), config.getSlaveSetID(), methodName, remoteIp, remotePort, ret, System.currentTimeMillis() - bornTime);

--- a/core/src/main/java/com/qq/tars/client/rpc/tars/TarsInvoker.java
+++ b/core/src/main/java/com/qq/tars/client/rpc/tars/TarsInvoker.java
@@ -149,7 +149,7 @@ public class TarsInvoker<T> extends ServantInvoker<T> {
     }
 
     @SuppressWarnings("unchecked")
-    private void invokeWithAsync(Method method, Object args[], Map<String, String> context) throws Throwable {
+    private void invokeWithAsync(Method method, Object[] args, Map<String, String> context) throws Throwable {
         ServantClient client = getClient();
         TarsServantRequest request = new TarsServantRequest(client.getIoSession());
         request.setVersion(TarsHelper.VERSION);
@@ -182,7 +182,7 @@ public class TarsInvoker<T> extends ServantInvoker<T> {
 
         DistributedContext distributedContext = DistributedContextManager.getDistributedContext();
         Boolean bDyeing = distributedContext.get(DyeingSwitch.BDYEING);
-        if (bDyeing != null && bDyeing == true) {
+        if (bDyeing != null && bDyeing) {
             request.setMessageType(request.getMessageType() | TarsHelper.MESSAGETYPEDYED);
             HashMap<String, String> status = new HashMap<>();
             String routeKey = distributedContext.get(DyeingSwitch.DYEINGKEY);

--- a/core/src/main/java/com/qq/tars/server/core/ServantHomeSkeleton.java
+++ b/core/src/main/java/com/qq/tars/server/core/ServantHomeSkeleton.java
@@ -73,13 +73,13 @@ public class ServantHomeSkeleton extends AppService {
         Object dataValue = value;
 
         if (dataType != null && dataValue != null) {
-            if ("short" == dataType.getName()) {
+            if ("short".equals(dataType.getName())) {
                 dataValue = Short.valueOf(dataValue.toString());
-            } else if ("byte" == dataType.getName()) {
+            } else if ("byte".equals(dataType.getName())) {
                 dataValue = Byte.valueOf(dataValue.toString());
             } else if (char.class == dataType) {
                 dataValue = ((String) value).charAt(0);
-            } else if ("float" == dataType.getName()) {
+            } else if ("float".equals(dataType.getName())) {
                 dataValue = Float.valueOf(dataValue.toString());
             }
         }

--- a/examples/quickstart-client/pom.xml
+++ b/examples/quickstart-client/pom.xml
@@ -12,9 +12,14 @@
     <dependencies>
         <dependency>
             <groupId>com.tencent.tars</groupId>
-            <artifactId>tars-client</artifactId>
+            <artifactId>tars-core</artifactId>
+            <version>1.7.0-SNAPSHOT</version>
+        </dependency> <dependency>
+            <groupId>com.tencent.tars</groupId>
+            <artifactId>tars-net</artifactId>
             <version>1.7.0-SNAPSHOT</version>
         </dependency>
+
     </dependencies>
     <build>
         <finalName>webapp</finalName>

--- a/examples/quickstart-server/pom.xml
+++ b/examples/quickstart-server/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.tencent.tars</groupId>
 		<artifactId>tars-parent</artifactId>
-		<version>1.6.1</version>
+		<version>1.7.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>tars-quickstart-server</artifactId>
 	<name>${project.artifactId}</name>


### PR DESCRIPTION
异步模式调用时，如果出现异常，Callback的onException方法会被调用两次导致bug！
bug原因：TarsCallbackFilterChain#doRealInvoke line:45 catch异常调用一次onException，之后再将异常抛出去
```
        protected void doRealInvoke(Request request, Response response)
			throws Throwable {
		if (request instanceof TarsServantRequest) {
			TarsServantResponse tarsServantResponse = (TarsServantResponse)response;
			if (expireFlag == 0) {
				try {
		            if (tarsServantResponse.getCause() != null) {
		                throw new TarsException(tarsServantResponse.getCause());
		            }
		            if (tarsServantResponse.getRet() != TarsHelper.SERVERSUCCESS) {
		                throw ServerException.makeException(tarsServantResponse.getRet());
		            }
		            if (target != null) {
		                this.target.onCompleted(tarsServantResponse);
		            }
		        } catch (Throwable ex) {
		        	if (target != null) {
		        		target.onException(ex);
		        	}
                                throw ex;
		        }
			} else if (expireFlag == 1) {
	            if (target != null) {
	                this.target.onExpired();
	            }
		}
		}
	}
```
被抛出后被TarsCallbackWrapper#onComplete方法catch后会再次调用callback.onException.
修复：删除最后一次callback.onException调用