### PR TITLE
修复Future调用模式中InvokeStatus的错误设置和异常多次调用

### DIFF
--- a/core/src/main/java/com/qq/tars/client/rpc/ServantClient.java
+++ b/core/src/main/java/com/qq/tars/client/rpc/ServantClient.java
@@ -179,7 +179,7 @@ public class ServantClient {
         Ticket<T> ticket = null;
         try {
             ensureConnected();
-            request.setInvokeStatus(InvokeStatus.ASYNC_CALL);
+            request.setInvokeStatus(InvokeStatus.FUTURE_CALL);
             ticket = TicketManager.createTicket(request, session, this.syncTimeout, callback);
 
             Session current = session;

--- a/core/src/main/java/com/qq/tars/client/rpc/tars/TarsInvoker.java
+++ b/core/src/main/java/com/qq/tars/client/rpc/tars/TarsInvoker.java
@@ -250,7 +250,7 @@ public class TarsInvoker<T> extends ServantInvoker<T> {
                 TarsInvoker.this,
                 completableFuture);
         //sync call all filter
-        final FilterChain filterChain = new TarsClientFilterChain(filters, objName, FilterKind.CLIENT, client, InvokeStatus.ASYNC_CALL,
+        final FilterChain filterChain = new TarsClientFilterChain(filters, objName, FilterKind.CLIENT, client, InvokeStatus.FUTURE_CALL,
                 callback);
         filterChain.doFilter(request, response);
         return completableFuture;

--- a/core/src/main/java/com/qq/tars/protocol/tars/support/TarsPromiseFutureCallback.java
+++ b/core/src/main/java/com/qq/tars/protocol/tars/support/TarsPromiseFutureCallback.java
@@ -50,19 +50,16 @@ public class TarsPromiseFutureCallback<V> implements Callback<TarsServantRespons
         int ret = Constants.INVOKE_STATUS_SUCC;
         try {
             if (response.getCause() != null) {
-                completableFuture.completeExceptionally(new TarsException(response.getCause()));
                 throw new TarsException(response.getCause());
 
             }
             if (response.getRet() != TarsHelper.SERVERSUCCESS) {
-                completableFuture.completeExceptionally(ServerException.makeException(response.getRet()));
                 throw ServerException.makeException(response.getRet());
             }
             TarsPromiseFutureCallback.this.completableFuture.complete((V) response.getResult());
         } catch (Throwable ex) {
             ret = Constants.INVOKE_STATUS_EXEC;
             logger.error("error occurred on callback completed", ex);
-            completableFuture.completeExceptionally(ServerException.makeException(ret));
             onException(ex);
         } finally {
             invoker.setAvailable(ServantInvokerAliveChecker.isAlive(invoker.getUrl(), config, ret));


### PR DESCRIPTION
1. future模式下调用时设置的`InvokeStatus`由原来之前错误的`ASYNC_CALL`改为`FUTRUE_CALL`
2. future模式在调用出现异常时多次调用`CompletableFuture.completeExceptionally`方法问题（虽然不影响结果，但是不符合语义）
@TimmyYu 