### PR TITLE
[ISSUE #108]avoid throwing exception when start server without stat and property

### DIFF
--- a/core/src/main/java/com/qq/tars/client/CommunicatorConfig.java
+++ b/core/src/main/java/com/qq/tars/client/CommunicatorConfig.java
@@ -32,7 +32,7 @@ public class CommunicatorConfig {
     private int refreshEndpointInterval = 60000;
     private int reportInterval = 60000;
 
-    private String stat = Constants.default_stat;
+    private String stat = null;
     private String property = null;
 
     private int sampleRate = 0;

--- a/core/src/main/java/com/qq/tars/support/property/PropertyReportHelper.java
+++ b/core/src/main/java/com/qq/tars/support/property/PropertyReportHelper.java
@@ -18,6 +18,7 @@ package com.qq.tars.support.property;
 
 import com.qq.tars.client.Communicator;
 import com.qq.tars.client.CommunicatorConfig;
+import com.qq.tars.common.util.StringUtils;
 import com.qq.tars.net.util.Utils;
 import com.qq.tars.rpc.exc.TarsException;
 import com.qq.tars.server.config.ConfigurationManager;
@@ -183,8 +184,12 @@ public class PropertyReportHelper {
             if (!initialized) {
                 return;
             }
-
-            PropertyFPrx propertyFPrx = communicator.stringToProxy(PropertyFPrx.class, ConfigurationManager.getInstance().getServerConfig().getCommunicatorConfig().getProperty());
+            String property=ConfigurationManager.getInstance().getServerConfig().getCommunicatorConfig().getProperty();
+            if(StringUtils.isEmpty(property)){
+                omLogger.info("no config property obj to report");
+                return;
+            }
+            PropertyFPrx propertyFPrx = communicator.stringToProxy(PropertyFPrx.class, property);
 
             Map<StatPropMsgHead, StatPropMsgBody> sendData = new HashMap<StatPropMsgHead, StatPropMsgBody>();
             int sendLen = 0;


### PR DESCRIPTION
work for this [issue](https://github.com/TarsCloud/TarsJava/issues/108).
add logic to avoid exception. 
When stat and property fields in config file are omitted, the report function will print log and return to avoid exception.