### PR TITLE
[ISSUE #112] decode all fields in decodeRequest to fix decode err when call with tarsGo client

### DIFF
--- a/core/src/main/java/com/qq/tars/rpc/protocol/tars/TarsCodec.java
+++ b/core/src/main/java/com/qq/tars/rpc/protocol/tars/TarsCodec.java
@@ -338,12 +338,20 @@ public class TarsCodec extends Codec {
             int requestId = jis.read(TarsHelper.STAMP_INT.intValue(), 4, true);
             String servantName = jis.readString(5, true);
             String methodName = jis.readString(6, true);
+            byte[] data = jis.read(TarsHelper.STAMP_BYTE_ARRAY, 7, true);//数据
+            int timeout = jis.read(TarsHelper.STAMP_INT.intValue(), 8, true);//超时时间
+            Map<String, String> context = (Map<String, String>) jis.read(TarsHelper.STAMP_MAP, 9, true);//Map<String, String> context
+            Map<String, String> status = (Map<String, String>) jis.read(TarsHelper.STAMP_MAP, 10, true);
             request.setVersion(version);
             request.setPacketType(packetType);
             request.setMessageType(messageType);
             request.setRequestId(requestId);
             request.setServantName(servantName);
             request.setFunctionName(methodName);
+            request.setData(data);
+            request.setTimeout(timeout);
+            request.setContext(context);
+            request.setStatus(status);
             request.setInputStream(jis);
             request.setCharsetName(charsetName);
         } catch (Exception e) {
@@ -368,14 +376,6 @@ public class TarsCodec extends Codec {
             oldClassLoader = Thread.currentThread().getContextClassLoader();
             Thread.currentThread().setContextClassLoader(resolveProtocolClassLoader());
             String methodName = request.getFunctionName();
-            byte[] data = jis.read(TarsHelper.STAMP_BYTE_ARRAY, 7, true);//数据
-            int timeout = jis.read(TarsHelper.STAMP_INT.intValue(), 8, true);//超时时间
-            Map<String, String> context = (Map<String, String>) jis.read(TarsHelper.STAMP_MAP, 9, true);//Map<String, String> context
-            Map<String, String> status = (Map<String, String>) jis.read(TarsHelper.STAMP_MAP, 10, true);
-
-            request.setTimeout(timeout);
-            request.setContext(context);
-            request.setStatus(status);
 
             String servantName = request.getServantName();
             Map<String, TarsMethodInfo> methodInfoMap = AnalystManager.getInstance().getMethodMapByName(servantName);
@@ -396,12 +396,12 @@ public class TarsCodec extends Codec {
                 Object[] parameters = new Object[parametersList.size()];
                 int i = 0;
                 if (TarsHelper.VERSION == request.getVersion()) {//request
-                    parameters = decodeRequestBody(data, request.getCharsetName(), methodInfo);
+                    parameters = decodeRequestBody(request.getData(), request.getCharsetName(), methodInfo);
                 } else if (TarsHelper.VERSION2 == request.getVersion() || TarsHelper.VERSION3 == request.getVersion()) {
-                    parameters = decodeRequestWupBody(data, request.getVersion(), request.getCharsetName(), methodInfo);
+                    parameters = decodeRequestWupBody(request.getData(), request.getVersion(), request.getCharsetName(), methodInfo);
                 } else if (TarsHelper.VERSIONJSON == request.getVersion()) {
                     // System.out.println("requestId: " + request.getRequestId() + ", charset: " + request.getCharsetName() + ", data: " + new String(data, request.getCharsetName()));
-                    parameters = decodeRequestJsonBody(data, request.getCharsetName(), methodInfo);
+                    parameters = decodeRequestJsonBody(request.getData(), request.getCharsetName(), methodInfo);
                 } else {
                     request.setRet(TarsHelper.SERVERDECODEERR);
                     System.err.println("un supported protocol, ver=" + request.getVersion());

--- a/core/src/main/java/com/qq/tars/rpc/protocol/tars/TarsServantRequest.java
+++ b/core/src/main/java/com/qq/tars/rpc/protocol/tars/TarsServantRequest.java
@@ -33,6 +33,7 @@ public class TarsServantRequest extends ServantRequest implements java.io.Serial
     private int messageType;
     private String servantName;
     private String functionName;
+    private byte[] data;
     private int timeout; // iTimeout
     private Map<String, String> status;
     private Map<String, String> context;
@@ -115,6 +116,14 @@ public class TarsServantRequest extends ServantRequest implements java.io.Serial
 
     public void setRequestId(int requestId) {
         this.setTicketNumber(requestId);
+    }
+
+    public byte[] getData() {
+        return data;
+    }
+
+    public void setData(byte[] data) {
+        this.data = data;
     }
 
     public int getTimeout() {


### PR DESCRIPTION
resolve #112  
   [ISSUE #112 ](https://github.com/TarsCloud/TarsJava/issues/112)

Decode fields(tag 7,8,9,10) in decodeRequest instead of decodeRequestBody.
All fields of TarsServantRequest was decoded in decodeRequest to avoid some required filed not initialized. 