### PR TITLE
Fix bug: "nodes.equals(servantProxyConfig.getObjectName()))" always returns true for the same object. Cause the node status to not update

### DIFF
--- a/core/src/main/java/com/qq/tars/client/ObjectProxy.java
+++ b/core/src/main/java/com/qq/tars/client/ObjectProxy.java
@@ -189,7 +189,7 @@ public final class ObjectProxy<T> implements ServantProxy, InvocationHandler {
                 } else {
                     nodes = communicator.getQueryHelper().getServerNodes(servantProxyConfig);
                 }
-                if (nodes != null && !nodes.equals(servantProxyConfig.getObjectName())) {
+                if (nodes != null && !(nodes == servantProxyConfig.getObjectName())) {
                     servantCacheManager.save(communicator.getId(), servantProxyConfig.getSimpleObjectName(), nodes, communicator.getCommunicatorConfig().getDataPath());
                     servantProxyConfig.setObjectName(nodes);
                     refresh();


### PR DESCRIPTION
Fix bug: "nodes.equals(servantProxyConfig.getObjectName()))" always returns true for the same object. Cause the node status to not update