### PR TITLE
修复当一个jce出现多module时，由于分号导致无法解析后面的module

### DIFF
--- a/tools/tars-maven-plugin/src/main/java/com/qq/tars/maven/parse/TarsParser.java
+++ b/tools/tars-maven-plugin/src/main/java/com/qq/tars/maven/parse/TarsParser.java
@@ -181,6 +181,9 @@ public class TarsParser extends Parser {
 				int LA2_0 = input.LA(1);
 				if ( (LA2_0==TARS_NAMESPACE) ) {
 					alt2=1;
+				}else if (LA2_0 == SEMI) {
+					input.consume();
+					continue;
 				}
 
 				switch (alt2) {


### PR DESCRIPTION
jce文件中可能出现类型
```
module a
{
    ......
};
module b
{
    ......
};
```
目前查阅到相关语法说module后面是要跟分号的，但是目前的parser如果a后面加了分号 ，就解析不到b了
所以就简单的改了一下TarsParser的