### PR TITLE
fix build tars java file confict

### DIFF
--- a/tools/tars-maven-plugin/src/test/java/com/qq/tars/maven/BuildTest.java
+++ b/tools/tars-maven-plugin/src/test/java/com/qq/tars/maven/BuildTest.java
@@ -1,0 +1,86 @@
+package com.qq.tars.maven;
+
+import com.qq.tars.maven.gensrc.Tars2JavaConfig;
+import com.qq.tars.maven.gensrc.Tars2JavaMojo;
+import com.qq.tars.maven.parse.TarsLexer;
+import org.antlr.runtime.DFA;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.junit.Test;
+
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+
+public class BuildTest {
+
+    @Test
+    public void test() throws MojoFailureException, MojoExecutionException {
+
+        String[] args = getBuildArgs();
+
+        Tars2JavaMojo mojo = getTars2JavaMojo(args);
+        mojo.execute();
+    }
+
+    private Tars2JavaMojo getTars2JavaMojo(String[] args) {
+        Tars2JavaConfig config = new Tars2JavaConfig();
+        for (String arg : args) {
+            if (arg.startsWith("--") && arg.contains("=")) {
+                String[] kv = arg.split("=");
+                if (kv.length == 2) {
+                    if ("--servant".equals(kv[0])) {
+                        config.setServant("true".equalsIgnoreCase(kv[1]));
+                    }
+                    else if ("--charset".equals(kv[0])) {
+                        Charset charset = Charset.forName(kv[1]);
+                        config.setCharset(charset.displayName());
+                        config.setTafFileCharset(charset.displayName());
+                    }
+                    else if ("--package".equals(kv[0])) {
+                        String packageName = kv[1];
+                        config.setPackagePrefixName(packageName.endsWith(".") ? packageName : packageName + ".");
+                    }
+                    else if ("--output".equals(kv[0])) {
+                        config.setSrcPath(kv[1]);
+                    }
+                    else if ("--input".equals(kv[0])) {
+                        config.setTafFiles(kv[1].trim().split(","));
+                    }
+                    else if ("--tup".equals(kv[0])) {
+                        config.setTup("true".equalsIgnoreCase(kv[1]));
+                    } else if("--tarsFileCharset".equals(kv[0])) {
+                        config.setCharset(kv[1]);
+                    }
+                }
+            }
+        }
+        Tars2JavaMojo mojo = new Tars2JavaMojo();
+        mojo.setTars2JavaConfig(config);
+        return mojo;
+    }
+
+    public String[] getBuildArgs() {
+        List<String> params = new ArrayList<>();
+
+        params.add("--charset=UTF-8");
+        params.add("--package=com.qq.tars.maven.plugin");
+        params.add("--input=" + BuildTest.class.getClassLoader().getResource("StructCacheVarName.tars").getFile());
+        params.add("--output=/var/tmp");
+        params.add("--tup=true");
+        params.add("--type=all");
+        params.add("--simplifyJceSpec=true");
+        params.add("--usePrimitiveWrapper=true");
+        params.add("--allowPrimitiveNull=true");
+        params.add("--tarsFileCharset=UTF-8");
+
+        String[] arrs = new String[params.size()];
+        params.toArray(arrs);
+        return arrs;
+    }
+
+    @Test
+    public void test2() {
+        short[] DFA18_eot = DFA.unpackEncodedString(TarsLexer.DFA18_eotS);
+    }
+}

--- a/tools/tars-maven-plugin/src/test/resources/StructCacheVarName.tars
+++ b/tools/tars-maven-plugin/src/test/resources/StructCacheVarName.tars
@@ -1,0 +1,20 @@
+module Test {
+    struct CacheVarRequest {
+        0 require string name;
+        1 require long ord = 0;
+        2 require float ord2 = 1.1;
+        3 optional map<String,String> testMap;
+        4 optional vector<long> uids;
+        5 optional vector<byte> token;
+    };
+
+    struct CacheVarRequest2 {
+        0 require string name;
+        1 require long ord = 0;
+        2 require float ord2 = 1.1;
+        3 optional map<String,String> testMap;
+        4 optional vector<long> uids;
+        5 optional vector<byte> token;
+    };
+
+};


### PR DESCRIPTION
# 问题背景
* 编译插件生成的java 类文件的时候，一些缓存变量，使用的是全局计时器，如果一些使用方将这些文件放在代码仓库中，会有较多冲突；

# 修复方式
* 这些变量名的计数器和structname绑定，不适用全局的.