### PR TITLE
Fix “tars-spring-boot-http-server” example compilation error

### DIFF
--- a/examples/tars-spring-boot-http-server/pom.xml
+++ b/examples/tars-spring-boot-http-server/pom.xml
@@ -33,6 +33,11 @@
             <artifactId>tars-spring-boot-starter</artifactId>
             <version>2.0.0</version>
         </dependency>
+             <dependency>
+            <groupId>com.tencent.tars</groupId>
+            <artifactId>tars-logger-logback</artifactId>
+            <version>2.0.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/examples/tars-spring-boot-http-server/src/main/java/com/tencent/tars/client/testapp/HelloPrxCallback.java
+++ b/examples/tars-spring-boot-http-server/src/main/java/com/tencent/tars/client/testapp/HelloPrxCallback.java
@@ -5,9 +5,8 @@
 
 package com.tencent.tars.client.testapp;
 
-import com.qq.tars.rpc.protocol.tars.support.TarsAbstractCallback;
 
-public abstract class HelloPrxCallback extends TarsAbstractCallback {
+public abstract class HelloPrxCallback {
 
 	public abstract void callback_hello(String ret);
 


### PR DESCRIPTION

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.0:compile (default-compile) on project tars-spring-boot-http-server: Compilation failure: Compilation failure:
[ERROR] /D:/workspace/GitLab/TarsJava_2.0/TarsJava/examples/tars-spring-boot-http-server/src/main/java/com/tencent/tars/client/testapp/HelloPrxCallback.java:[8,45] 找不到符号
[ERROR]   符号:   类 TarsAbstractCallback
[ERROR]   位置: 程序包 com.qq.tars.rpc.protocol.tars.support
[ERROR] /D:/workspace/GitLab/TarsJava_2.0/TarsJava/examples/tars-spring-boot-http-server/src/main/java/com/tencent/tars/client/testapp/HelloPrxCallback.java:[10,48] 找不到符号
[ERROR]   符号: 类 TarsAbstractCallback
[ERROR] -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
PS D:\workspace\GitLab\TarsJava_2.0\TarsJava\examples\tars-spring-boot-http-server>