### PR TITLE
Could com.tencent.tars:tars-maven-plugin:2.0.0 drop off redundant dependencies to loose weight?

### DIFF
--- a/tools/tars-maven-plugin/pom.xml
+++ b/tools/tars-maven-plugin/pom.xml
@@ -51,12 +51,31 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-nop</artifactId>
                 </exclusion>
+                    <exclusion>
+                    <groupId>org.sonatype.plexus</groupId>
+                    <artifactId>plexus-sec-dispatcher</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.maven.reporting</groupId>
+                    <artifactId>maven-reporting-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.maven.wagon</groupId>
+                    <artifactId>wagon-http</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.maven</groupId>
+                    <artifactId>maven-plugin-parameter-documenter</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.maven</groupId>
+                    <artifactId>maven-monitor</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.maven.doxia</groupId>
+                    <artifactId>doxia-logging-api</artifactId>
+                </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-plugin-parameter-documenter</artifactId>
-            <version>${maven_version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
@@ -71,11 +90,6 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-descriptor</artifactId>
-            <version>${maven_version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-monitor</artifactId>
             <version>${maven_version}</version>
         </dependency>
         <dependency>
@@ -99,6 +113,12 @@
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-filtering</artifactId>
             <version>1.3</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.sonatype.plexus</groupId>
+                    <artifactId>plexus-build-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.shared</groupId>


### PR DESCRIPTION
@TimmyYu Hi, I am a user of project **_com.tencent.tars:tars-maven-plugin:2.0.0_**. I found that its pom file introduced **_67_** dependencies. However, among them, **_9_** libraries (**_13%_**) have not been used by your project (the redundant dependencies are listed below). Reduce these useless dependencies can help prevent conflicts between library versions. MeanWhile, it can minimize the total added size to projects. It can also help enable advanced scenarios for this project. 
This PR helps **_com.tencent.tars:tars-maven-plugin:2.0.0_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards