### PR TITLE
use revision to do version-controll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ target/
 *.dat
 examples/**/testapp/
 **/.DS_Store
+.flattened-pom.xml

--- a/core/client.pom.xml
+++ b/core/client.pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.tencent.tars</groupId>
         <artifactId>tars-parent</artifactId>
-        <version>1.7.2</version>
+        <version>${revision}</version>
     </parent>
     <artifactId>tars-client</artifactId>
     <name>${project.artifactId}</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,7 +6,8 @@
     <parent>
         <groupId>com.tencent.tars</groupId>
         <artifactId>tars-parent</artifactId>
-        <version>1.7.2</version>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>tars-core</artifactId>
     <name>${project.artifactId}</name>

--- a/core/server.pom.xml
+++ b/core/server.pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.tencent.tars</groupId>
         <artifactId>tars-parent</artifactId>
-        <version>1.7.2</version>
+        <version>${revision}</version>
     </parent>
     <artifactId>tars-server</artifactId>
     <name>${project.artifactId}</name>

--- a/distributedContext/pom.xml
+++ b/distributedContext/pom.xml
@@ -6,7 +6,8 @@
     <parent>
         <groupId>com.tencent.tars</groupId>
         <artifactId>tars-parent</artifactId>
-        <version>1.7.2</version>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>tars-context</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -5,7 +5,8 @@
     <parent>
         <groupId>com.tencent.tars</groupId>
         <artifactId>tars-parent</artifactId>
-        <version>1.7.2</version>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>tars-examples</artifactId>
     <name>${project.artifactId}</name>

--- a/examples/quickstart-client/pom.xml
+++ b/examples/quickstart-client/pom.xml
@@ -13,11 +13,11 @@
         <dependency>
             <groupId>com.tencent.tars</groupId>
             <artifactId>tars-core</artifactId>
-            <version>1.7.2</version>
+            <version>${revision}</version>
         </dependency> <dependency>
             <groupId>com.tencent.tars</groupId>
             <artifactId>tars-net</artifactId>
-            <version>1.7.2</version>
+            <version>${revision}</version>
         </dependency>
 
     </dependencies>

--- a/examples/quickstart-server/pom.xml
+++ b/examples/quickstart-server/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.tencent.tars</groupId>
 		<artifactId>tars-parent</artifactId>
-		<version>1.7.2</version>
+		<version>${revision}</version>
 	</parent>
 	<artifactId>tars-quickstart-server</artifactId>
 	<name>${project.artifactId}</name>

--- a/examples/stress-server/pom.xml
+++ b/examples/stress-server/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.tencent.tars</groupId>
 		<artifactId>tars-parent</artifactId>
-		<version>1.7.2</version>
+		<version>${revision}</version>
 	</parent>
 	<artifactId>tars-stress-server</artifactId>
 	<name>${project.artifactId}</name>

--- a/examples/tars-spring-boot-client/pom.xml
+++ b/examples/tars-spring-boot-client/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>com.tencent.tars</groupId>
             <artifactId>tars-spring-boot-starter</artifactId>
-            <version>1.7.2</version>
+            <version>${revision}</version>
         </dependency>
     </dependencies>
 
@@ -84,7 +84,7 @@
                 <plugin>
                     <groupId>com.tencent.tars</groupId>
                     <artifactId>tars-maven-plugin</artifactId>
-                    <version>1.7.2</version>
+                    <version>${revision}</version>
                     <configuration>
                         <tars2JavaConfig>
                             <!-- tars文件位置 -->

--- a/examples/tars-spring-boot-http-server/pom.xml
+++ b/examples/tars-spring-boot-http-server/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.tencent.tars</groupId>
             <artifactId>tars-spring-boot-starter</artifactId>
-            <version>1.7.2</version>
+            <version>${revision}</version>
         </dependency>
     </dependencies>
 
@@ -81,7 +81,7 @@
                 <plugin>
                     <groupId>com.tencent.tars</groupId>
                     <artifactId>tars-maven-plugin</artifactId>
-                    <version>1.7.2</version>
+                    <version>${revision}</version>
                     <configuration>
                         <tars2JavaConfig>
                             <!-- tars文件位置 -->

--- a/examples/tars-spring-boot-server/pom.xml
+++ b/examples/tars-spring-boot-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tars-examples</artifactId>
         <groupId>com.tencent.tars</groupId>
-        <version>1.7.2</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.tencent.tars</groupId>
             <artifactId>tars-spring-boot-starter</artifactId>
-            <version>1.7.2</version>
+            <version>${revision}</version>
         </dependency>
     </dependencies>
 

--- a/examples/tars-spring-cloud-client/pom.xml
+++ b/examples/tars-spring-cloud-client/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.tencent.tars</groupId>
   <artifactId>tars-spring-cloud-client</artifactId>
-  <version> 1.7.2</version>
+  <version> ${revision}</version>
   <packaging>war</packaging>
 
   <name>tars-spring-cloud-client</name>
@@ -23,22 +23,22 @@
     <dependency>
       <groupId>com.tencent.tars</groupId>
       <artifactId>tars-core</artifactId>
-      <version> 1.7.2</version>
+      <version> ${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.tencent.tars</groupId>
       <artifactId>tars-spring</artifactId>
-      <version>1.7.2</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.tencent.tars</groupId>
       <artifactId>tars-protobuf</artifactId>
-      <version>1.7.2</version>
+      <version>${revision}</version>
     </dependency>
         <dependency>
       <groupId>com.tencent.tars</groupId>
       <artifactId>tars-spring-cloud-starter</artifactId>
-      <version> 1.7.2</version>
+      <version> ${revision}</version>
     </dependency>
   </dependencies>
 </project>

--- a/examples/tars-spring-cloud-server/pom.xml
+++ b/examples/tars-spring-cloud-server/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.tencent.tars</groupId>
   <artifactId>tars-spring-cloud-server</artifactId>
   <packaging>war</packaging>
-  <version>1.7.2</version>
+  <version>${revision}</version>
   
   <name>tars-spring-cloud-server</name>
   <url>http://maven.apache.org</url>
@@ -43,22 +43,22 @@
     <dependency>
       <groupId>com.tencent.tars</groupId>
       <artifactId>tars-core</artifactId>
-      <version> 1.7.2</version>
+      <version> ${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.tencent.tars</groupId>
       <artifactId>tars-spring</artifactId>
-      <version>1.7.2</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>com.tencent.tars</groupId>
       <artifactId>tars-protobuf</artifactId>
-      <version>1.7.2</version>
+      <version>${revision}</version>
     </dependency>
         <dependency>
       <groupId>com.tencent.tars</groupId>
       <artifactId>tars-spring-cloud-starter</artifactId>
-      <version>1.7.2</version>
+      <version>${revision}</version>
     </dependency>
   </dependencies>
   

--- a/examples/tars-spring-server/pom.xml
+++ b/examples/tars-spring-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tars-examples</artifactId>
         <groupId>com.tencent.tars</groupId>
-        <version> 1.7.2</version>
+        <version> ${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>war</packaging>

--- a/net/pom.xml
+++ b/net/pom.xml
@@ -6,7 +6,8 @@
     <parent>
         <groupId>com.tencent.tars</groupId>
         <artifactId>tars-parent</artifactId>
-        <version>1.7.2</version>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>tars-net</artifactId>
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.tencent.tars</groupId>
     <artifactId>tars-parent</artifactId>
-    <version>1.7.2</version>
+    <version>${revision}</version>
     <packaging>pom</packaging>
     <name>Tars</name>
     <description>Super POM For Projects</description>
@@ -50,6 +50,7 @@
     </modules>
 
     <properties>
+        <revision>1.7.2</revision>
         <java_source_version>1.8</java_source_version>
         <java_target_version>1.8</java_target_version>
         <file_encoding>UTF-8</file_encoding>
@@ -63,6 +64,7 @@
         <maven_deploy_plugin_version>2.8.2</maven_deploy_plugin_version>
         <maven_release_plugin_version>2.5.3</maven_release_plugin_version>
         <maven_junit_version>4.8.2</maven_junit_version>
+        <maven_flatten_version>1.2.5</maven_flatten_version>
     </properties>
 
     <build>
@@ -76,6 +78,32 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>${maven_javadoc_plugin_version}</version>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>${maven_flatten_version}</version>
+                <configuration>
+                    <updatePomFile>true</updatePomFile>
+                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
 

--- a/protobuf/pom.xml
+++ b/protobuf/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tars-parent</artifactId>
         <groupId>com.tencent.tars</groupId>
-        <version>1.7.2</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>tars-parent</artifactId>
         <groupId>com.tencent.tars</groupId>
-        <version>1.7.2</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring/tars-spring-boot-starter/pom.xml
+++ b/spring/tars-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tars-spring-parent</artifactId>
         <groupId>com.tencent.tars</groupId>
-        <version>1.7.2</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/spring/tars-spring-cloud-starter/pom.xml
+++ b/spring/tars-spring-cloud-starter/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>tars-spring-parent</artifactId>
 		<groupId>com.tencent.tars</groupId>
-		<version>1.7.2</version>
+		<version>${revision}</version>
 	</parent>
 
 	<artifactId>tars-spring-cloud-starter</artifactId>

--- a/spring/tars-spring/pom.xml
+++ b/spring/tars-spring/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>tars-spring-parent</artifactId>
 		<groupId>com.tencent.tars</groupId>
-		<version>1.7.2</version>
+		<version>${revision}</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/tars-plugins/pom.xml
+++ b/tars-plugins/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>tars-parent</artifactId>
         <groupId>com.tencent.tars</groupId>
-        <version>1.7.2</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>tars-plugins</artifactId>
@@ -16,7 +16,7 @@
         <maven.compiler.source>${targetJdk}</maven.compiler.source>
         <maven.compiler.target>${targetJdk}</maven.compiler.target>
         <encoding>UTF-8</encoding>
-        <slf4j.version>1.7.25</slf4j.version>
+        <slf4j.version>${revision}5</slf4j.version>
     </properties>
     <dependencies>
         <dependency>
@@ -28,12 +28,12 @@
         <dependency>
             <groupId>com.tencent.tars</groupId>
             <artifactId>tars-client</artifactId>
-            <version>1.7.2</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>com.tencent.tars</groupId>
             <artifactId>tars-server</artifactId>
-            <version>1.7.2</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.tencent.tars</groupId>
         <artifactId>tars-parent</artifactId>
-        <version>1.7.2</version>
+        <version>${revision}</version>
     </parent>
     <artifactId>tars-tools</artifactId>
     <name>${project.artifactId}</name>

--- a/tools/tars-maven-plugin/pom.xml
+++ b/tools/tars-maven-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.tencent.tars</groupId>
         <artifactId>tars-tools</artifactId>
-        <version>1.7.2</version>
+        <version>${revision}</version>
     </parent>
     <artifactId>tars-maven-plugin</artifactId>
     <name>${project.artifactId}</name>


### PR DESCRIPTION
* 使用当前开源项目比较流行的revision去做版本升级，简化版本更新操作以及避免多人协作的冲突解决.
* maven版本建议> 3.5.0
* issue：https://github.com/TarsCloud/TarsJava/issues/185